### PR TITLE
Pull docker images.

### DIFF
--- a/scripts/docker-containers.sh
+++ b/scripts/docker-containers.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -eu
+
+CONTAINERS=(
+  "clue/httpie"
+  "mysql"
+  "selenium/hub"
+  "shouldbee/ansible-boto"
+  "shouldbee/baseimage-go"
+  "shouldbee/bootstrap-compile-kit"
+  "shouldbee/codecept"
+  "shouldbee/coffeescript"
+  "shouldbee/dredd"
+  "shouldbee/flyway"
+  "shouldbee/go"
+  "shouldbee/html2pdf"
+  "shouldbee/nginx-https-reverse-proxy"
+  "shouldbee/phantomjs"
+  "shouldbee/php"
+  "shouldbee/php-cs-fixer"
+  "shouldbee/scala"
+  "shouldbee/selenium"
+  "shouldbee/selenium-node-chrome"
+  "shouldbee/selenium-node-firefox"
+  "shouldbee/tcpproxy"
+  "sylvainlasnier/memcached"
+)
+
+# parallel download
+printf "%s\n" "${CONTAINERS[@]}" | xargs -L1 -P0 docker pull

--- a/template.json
+++ b/template.json
@@ -7,8 +7,8 @@
     "builders": [
         {
             "type": "vmware-iso",
-	          "iso_url": "http://ftp.jaist.ac.jp/pub/Linux/ubuntu-releases/trusty/ubuntu-14.04-server-amd64.iso",
-            "iso_checksum": "ababb88a492e08759fddcf4f05e5ccc58ec9d47fa37550d63931d0a5fa4f7388",
+            "iso_url": "http://ftp.jaist.ac.jp/pub/Linux/ubuntu-releases/trusty/ubuntu-14.04.2-server-amd64.iso",
+            "iso_checksum": "8acd2f56bfcba2f7ac74a7e4a5e565ce68c024c38525c0285573e41c86ae90c0",
             "iso_checksum_type": "sha256",
             "boot_wait": "5s",
             "boot_command": [
@@ -29,8 +29,8 @@
         },
         {
             "type": "virtualbox-iso",
-	          "iso_url": "http://ftp.jaist.ac.jp/pub/Linux/ubuntu-releases/trusty/ubuntu-14.04-server-amd64.iso",
-            "iso_checksum": "ababb88a492e08759fddcf4f05e5ccc58ec9d47fa37550d63931d0a5fa4f7388",
+            "iso_url": "http://ftp.jaist.ac.jp/pub/Linux/ubuntu-releases/trusty/ubuntu-14.04.2-server-amd64.iso",
+            "iso_checksum": "8acd2f56bfcba2f7ac74a7e4a5e565ce68c024c38525c0285573e41c86ae90c0",
             "iso_checksum_type": "sha256",
             "boot_wait": "5s",
             "boot_command": [
@@ -87,6 +87,13 @@
             "type": "shell",
             "scripts": [
                 "scripts/docker.sh"
+            ],
+            "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'"
+        },
+        {
+            "type": "shell",
+            "scripts": [
+                "scripts/docker-containers.sh"
             ],
             "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'"
         },


### PR DESCRIPTION
These images will be pulled on provisioning.

```
  "clue/httpie"
  "mysql"
  "selenium/hub"
  "shouldbee/ansible-boto"
  "shouldbee/baseimage-go"
  "shouldbee/bootstrap-compile-kit"
  "shouldbee/codecept"
  "shouldbee/coffeescript"
  "shouldbee/dredd"
  "shouldbee/flyway"
  "shouldbee/go"
  "shouldbee/html2pdf"
  "shouldbee/nginx-https-reverse-proxy"
  "shouldbee/phantomjs"
  "shouldbee/php"
  "shouldbee/php-cs-fixer"
  "shouldbee/scala"
  "shouldbee/selenium"
  "shouldbee/selenium-node-chrome"
  "shouldbee/selenium-node-firefox"
  "shouldbee/tcpproxy"
  "sylvainlasnier/memcached"
```

Also, ubuntu-14.04-server-amd64.iso has been outdated. This PR updates Ubuntu to version 14.04.2.